### PR TITLE
Add support for lowercase headers

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -9,8 +9,8 @@
 // Get stuff
 $headers = getallheaders();
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$url = $headers['X-Proxy-Url'] ?? null;
-$cookie = $headers['X-Proxy-Cookie'] ?? null;
+$url = $headers['X-Proxy-Url'] ?? $headers['x-proxy-url'] ?? null;
+$cookie = $headers['X-Proxy-Cookie'] ?? $headers['x-proxy-cookie'] ?? null;
 
 
 


### PR DESCRIPTION
This pull request adds support for lower-cased versions of the `X-Proxy-Url` and `X-Proxy-Cookie` headers.

Some systems (like the one I use) normalize all header names to lower case, and the HTTP spec (http://www.ietf.org/rfc/rfc2616.txt) says that header field names are case-insensitive:


> 4.2 Message Headers
> 
> ... Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive. ...